### PR TITLE
Move attempt at race prevention up in the queue

### DIFF
--- a/modules/01-filter.js
+++ b/modules/01-filter.js
@@ -239,7 +239,6 @@ async function processCardAction(interaction) {
     // Prevent double-processing
     if (processing.has(flag.id)) {
       await interaction.reply({ content: "Someone is already processing this flag!", ephemeral: true });
-      u.clean(interaction);
       return;
     }
     processing.add(flag.id);

--- a/modules/01-filter.js
+++ b/modules/01-filter.js
@@ -235,11 +235,7 @@ async function warnCard(msg, filtered, call) {
  */
 async function processCardAction(interaction) {
   try {
-    const flag = interaction.message,
-      mod = interaction.member,
-      embed = u.embed(flag.embeds[0]),
-      infraction = await Module.db.infraction.getByFlag(flag);
-
+    const flag = interaction.message;
     // Prevent double-processing
     if (processing.has(flag.id)) {
       await interaction.reply({ content: "Someone is already processing this flag!", ephemeral: true });
@@ -247,6 +243,10 @@ async function processCardAction(interaction) {
       return;
     }
     processing.add(flag.id);
+
+    const mod = interaction.member,
+      embed = u.embed(flag.embeds[0]),
+      infraction = await Module.db.infraction.getByFlag(flag);
 
     // NEED TO ADD RETRACTIONS
 


### PR DESCRIPTION
The `await` to fetch the infraction is likely the source of delay that let a race condition get through in testing. This moves the race check up so it happens before any `await` calls.