### PR TITLE
Filter leaderboard results as intended

### DIFF
--- a/utils/dbModels.js
+++ b/utils/dbModels.js
@@ -184,7 +184,7 @@ const models = {
       const params = { excludeXP: false };
       if (members) params.discordId = { $in: members };
 
-      const query = User.find();
+      const query = User.find(params);
       if (season) query.sort({ currentXP: "desc" });
       else query.sort({ totalXP: "desc" });
 


### PR DESCRIPTION
In `slashRankLeaderboard`, two parameters are defined to filter the DB query (find only members currently choosing to track XP, and find only members listed in the passed object - generally members still within LDSG). Those filter parameters were mistakenly omitted from the query itself. This PR fixes that.