### PR TITLE
Ensure member exists before accessing attributes, skip otherwise

### DIFF
--- a/modules/rank.js
+++ b/modules/rank.js
@@ -127,7 +127,8 @@ const Module = new Augur.Module()
         if (response.users.length > 0) {
           const ldsg = client.guilds.cache.get(Module.config.ldsg);
           for (const user of response.users) {
-            const member = ldsg.members.cache.get(user.discordId);
+            const member = ldsg.members.cache.get(user.discordId) ?? await ldsg.members.cache.fetch(user.discordId);
+            if (!member) continue;
 
             // Remind mods to trust people!
             if ((user.posts % 25 == 0) && !member.roles.cache.has(Module.config.roles.trusted) && !member.roles.cache.has(Module.config.roles.untrusted)) {

--- a/modules/rank.js
+++ b/modules/rank.js
@@ -127,7 +127,7 @@ const Module = new Augur.Module()
         if (response.users.length > 0) {
           const ldsg = client.guilds.cache.get(Module.config.ldsg);
           for (const user of response.users) {
-            const member = ldsg.members.cache.get(user.discordId) ?? await ldsg.members.cache.fetch(user.discordId);
+            const member = ldsg.members.cache.get(user.discordId) ?? await ldsg.members.fetch(user.discordId);
             if (!member) continue;
 
             // Remind mods to trust people!


### PR DESCRIPTION
Instead of just getting a member object from the guild cache: fall back to fetching a member object and skip that user if no member is found.

This is intended to fix the recurring "Rank inner clockwork" error (example at https://discord.com/channels/96335850576556032/209046676781006849/906779543979819049). Line 133 (old line count) currently errors when a `member` returned from the guild cache is undefined.